### PR TITLE
[Issue#75] - Version 18 Se incluyen nuevos nodos y validaciones de 44 para FEE

### DIFF
--- a/l10n_cr/cr_electronic_invoice/models/account_move.py
+++ b/l10n_cr/cr_electronic_invoice/models/account_move.py
@@ -1298,7 +1298,10 @@ class AccountInvoiceElectronic(models.Model):
                                 _no_cabys_code = _(f'Warning!.\nLine without CABYS code: {inv_line.name}')
                                 continue
 
-                            if inv.tipo_documento == 'FEE' and inv_line.tariff_head:
+                            # Validación: Deberá incluir al menos 12 dígitos cuando se
+                            # trate de una FEE, NC o ND que modifiquen una FEE y que el
+                            # primer digito del código CABYS sea 0, 1, 2, 3 y 4 (bienes).
+                            if inv.tipo_documento == 'FEE' and inv_line.tariff_head and inv_line.product_id.cabys_product_id.cabys_categoria1_id.codigo in ['0','1','2','3','4']:
                                 line["partidaArancelaria"] = inv_line.tariff_head
 
                             if inv_line.discount and price_unit > 0:

--- a/l10n_cr/cr_electronic_invoice/models/api_facturae.py
+++ b/l10n_cr/cr_electronic_invoice/models/api_facturae.py
@@ -452,15 +452,10 @@ def gen_xml_v43(inv, sale_conditions, total_servicio_gravado,
         if receiver_company.name:
             sb.append('<Receptor>')
             sb.append('<Nombre>' + escape(str(receiver_company.name[:99])) + '</Nombre>')
-
-            if inv.tipo_documento == 'FEE' or id_code == '05':
-                if receiver_company.vat:
-                    sb.append('<IdentificacionExtranjero>' + str(receiver_company.vat) + '</IdentificacionExtranjero>')
-            else:
-                sb.append('<Identificacion>')
-                sb.append('<Tipo>' + str(id_code) + '</Tipo>')
-                sb.append('<Numero>' + str(vat) + '</Numero>')
-                sb.append('</Identificacion>')
+            sb.append('<Identificacion>')
+            sb.append('<Tipo>' + str(id_code) + '</Tipo>')
+            sb.append('<Numero>' + str(vat) + '</Numero>')
+            sb.append('</Identificacion>')
 
             if inv.tipo_documento != 'FEE':
                 if receiver_company.state_id and \
@@ -480,15 +475,15 @@ def gen_xml_v43(inv, sale_conditions, total_servicio_gravado,
                     sb.append('<OtrasSenas>' + escape(str(receiver_company.street or 'No disponible')) + '</OtrasSenas>')
                     sb.append('</Ubicacion>')
 
-                if receiver_company.phone:
-                    try:
-                        phone = phonenumbers.parse(receiver_company.phone, (receiver_company.country_id.code or 'CR'))
-                        sb.append('<Telefono>')
-                        sb.append('<CodigoPais>' + str(phone.country_code) + '</CodigoPais>')
-                        sb.append('<NumTelefono>' + str(phone.national_number) + '</NumTelefono>')
-                        sb.append('</Telefono>')
-                    except:
-                        pass
+            if receiver_company.phone:
+                try:
+                    phone = phonenumbers.parse(receiver_company.phone, (receiver_company.country_id.code or 'CR'))
+                    sb.append('<Telefono>')
+                    sb.append('<CodigoPais>' + str(phone.country_code) + '</CodigoPais>')
+                    sb.append('<NumTelefono>' + str(phone.national_number) + '</NumTelefono>')
+                    sb.append('</Telefono>')
+                except:
+                    pass
 
                 re_match = r'^(\s?[^\s,]+@[^\s,]+\.[^\s,]+\s?,)*(\s?[^\s,]+@[^\s,]+\.[^\s,]+)$'
                 match = receiver_company.email and re.match(re_match, receiver_company.email.lower())
@@ -539,7 +534,7 @@ def gen_xml_v43(inv, sale_conditions, total_servicio_gravado,
 
             sb.append('<SubTotal>' + str(v['subtotal']) + '</SubTotal>')
 
-            if inv.tipo_documento != 'FEE' or inv.tipo_documento != 'REP':
+            if inv.tipo_documento not in ['FEE', 'REP']:
                 if v['impuesto'][1]['codigo']=='01' and v['subtotal'] > 0:
                     sb.append('<BaseImponible>' + str(v['subtotal']) + '</BaseImponible>')
                 
@@ -586,8 +581,10 @@ def gen_xml_v43(inv, sale_conditions, total_servicio_gravado,
                             sb.append('</Exoneracion>')
                     sb.append('</Impuesto>')
 
-                sb.append('<ImpuestoAsumidoEmisorFabrica>' + str(0) + '</ImpuestoAsumidoEmisorFabrica>')
-                sb.append('<ImpuestoNeto>' + str(v['impuestoNeto']) + '</ImpuestoNeto>')
+                if inv.tipo_documento not in ['FEE','FEC','REP']:
+                    sb.append('<ImpuestoAsumidoEmisorFabrica>' + str(0) + '</ImpuestoAsumidoEmisorFabrica>')
+                if inv.tipo_documento != 'FEE':
+                    sb.append('<ImpuestoNeto>' + str(v['impuestoNeto']) + '</ImpuestoNeto>')
 
             sb.append('<MontoTotalLinea>' + str(v['montoTotalLinea']) + '</MontoTotalLinea>')
             sb.append('</LineaDetalle>')


### PR DESCRIPTION
- partidaArancelaria: Deberá incluir al menos 12 dígitos cuando se trate de una FEE, NC o ND que modifiquen una FEE y que el primer dígito del código CABYS sea 0, 1, 2, 3 y 4 (bienes).

- Se ajustan validaciones según tipo de documentos.