### PR TITLE
[Fix] Correccion en request de Hacienda y ajuste de multicompany.

### DIFF
--- a/l10n_cr/res_currency_cr_adapter/data/currency_data.xml
+++ b/l10n_cr/res_currency_cr_adapter/data/currency_data.xml
@@ -6,7 +6,7 @@
         <field name="digits">15</field>
     </record>
     <record id="currency_crc_rate_cron" model="ir.cron">
-        <field name="name">Currency CRC Rate Update</field>
+        <field name="name">ODOOCR: Currency CRC Rate Update</field>
         <field name="model_id" ref="model_res_currency_rate"/>
         <field name="state">code</field>
         <field name="code">model._cron_update()</field>
@@ -18,7 +18,7 @@
         <field name="active" eval="True"/>
     </record>
     <record id="create_missing_exchange_rate_cron" model="ir.cron">
-        <field name="name">Create Missing Exchange Rate</field>
+        <field name="name">ODOOCR: Create Missing Exchange Rate</field>
         <field name="model_id" ref="model_res_currency"/>
         <field name="state">code</field>
         <field name="code">model._cron_create_missing_exchange_rates()</field>

--- a/l10n_cr/res_currency_cr_adapter/models/res_currency.py
+++ b/l10n_cr/res_currency_cr_adapter/models/res_currency.py
@@ -19,39 +19,43 @@ class ResCurrency(models.Model):
     # -------------------------------------------------------------------------
 
     def _cron_create_missing_exchange_rates(self):
-        for currency in self.env['res.currency'].search([('id', '!=', self.env.user.company_id.currency_id.id)]):
-            currency.action_create_missing_exchange_rates()
+        # Obtener el registro de la compañía principal
+        main_company = self.env['res.company']._get_main_company()
+        # Iterar sobre las monedas, pero ejecutar la acción con el contexto de la compañía principal
+        for currency in self.env['res.currency'].search([('id', '!=', main_company.currency_id.id)]):
+            currency.with_company(main_company).action_create_missing_exchange_rates()
 
     # -------------------------------------------------------------------------
     # PUBLIC ACTIONS
     # -------------------------------------------------------------------------
 
     def action_create_missing_exchange_rates(self):
-        currency_rate_obj = self.env['res.currency.rate']
+        # La compañía principal de la instancia, no la del usuario
+        main_company = self.env['res.company']._get_main_company()
+        
+        # Usamos with_company() para cambiar el contexto temporalmente.
+        currency_rate_obj = self.env['res.currency.rate'].with_company(main_company)
+        
         # A day is added to fix the loss of the current day
         today = datetime.today().date()
         last_day = today + timedelta(days=1)
 
         first_day = currency_rate_obj.search([
-            ('company_id', '=', self.env.user.company_id.id),
+            ('company_id', '=', main_company.id),
             ('currency_id', '=', self.id)
         ], limit=1, order='name asc')
-        # If there is no record, you must fill the table with the current day
+        
         if not first_day:
-            # It is validated that the currency is dollars
             if self.id == self.env.ref('base.USD').id:
-                # This will create the record of the day the option is run manually
-                currency_rate_obj._cron_update()
+                # La llamada a _cron_update también debe ser con el contexto de la compañía principal
+                self.env['res.currency.rate'].with_company(main_company)._cron_update()
         else:
             range_day = last_day - first_day.name
             date = first_day.name
             for day in range(range_day.days):
                 if self.id == self.env.ref('base.USD').id:
-                    # It is validated if the exchange rate of that day really not exists
                     if not currency_rate_obj.search([('name', '=', date)], limit=1):
-                        # TODO: It could be improved to make only one request and avoid one per day
-                        currency_rate_obj._cron_update(date, date)
-                    # If after updating it does not exist, it will be loaded on the last available day
+                        self.env['res.currency.rate'].with_company(main_company)._cron_update(date, date)
                     if not currency_rate_obj.search([('name', '=', date)], limit=1):
-                        currency_rate_obj._create_the_latest_exchange_rate_to_date(self, date)
+                        self.env['res.currency.rate'].with_company(main_company)._create_the_latest_exchange_rate_to_date(self, date)
                 date += timedelta(days=1)

--- a/l10n_cr/res_currency_cr_adapter/models/res_currency_rate.py
+++ b/l10n_cr/res_currency_cr_adapter/models/res_currency_rate.py
@@ -127,192 +127,138 @@ class ResCurrencyRate(models.Model):
 
     @api.model
     def _cron_update(self, first_date=False, last_date=False):
-
         _logger.info("=========================================================")
-        _logger.info("Executing exchange rate update from 1 CRC = X USD")
+        _logger.info("Executing exchange rate update")
+
+        # Usar el contexto de la compañía principal para todas las operaciones de tasas de cambio
+        main_company = self.env['res.company']._get_main_company()
+        currency_rate_obj = self.env['res.currency.rate'].with_company(main_company)
 
         exchange_source = self.env['ir.config_parameter'].sudo().get_param('exchange_source')
+        usd_currency = self.env.ref('base.USD')
+        
+        if not usd_currency:
+            _logger.error("Error: La moneda USD (Dólares Americanos) no se encontró.")
+            return
+
         if exchange_source == 'bccr':
             _logger.info("Getting exchange rates from BCCR")
             bccr_username = self.env['ir.config_parameter'].sudo().get_param('bccr_username')
             bccr_email = self.env['ir.config_parameter'].sudo().get_param('bccr_email')
             bccr_token = self.env['ir.config_parameter'].sudo().get_param('bccr_token')
 
-            # Get current date to get exchange rate for today
             if first_date:
-                initial_date = first_date.strftime('%d/%m/%Y')
-                end_date = last_date.strftime('%d/%m/%Y')
+                initial_date_str = first_date.strftime('%d/%m/%Y')
+                end_date_str = last_date.strftime('%d/%m/%Y')
             else:
-                initial_date = datetime.now().date().strftime('%d/%m/%Y')
-                end_date = initial_date
+                initial_date_str = datetime.now().date().strftime('%d/%m/%Y')
+                end_date_str = initial_date_str
 
-            # Web Service Connection using the XML schema from BCCRR
-            client = Client('https://gee.bccr.fi.cr/Indicadores/Suscripciones/WS/wsindicadoreseconomicos.asmx?WSDL')
+            try:
+                client = Client('https://gee.bccr.fi.cr/Indicadores/Suscripciones/WS/wsindicadoreseconomicos.asmx?WSDL')
+                
+                # Obtener la tasa de venta (318)
+                response_venta = client.service.ObtenerIndicadoresEconomicosXML(
+                    Indicador='318', FechaInicio=initial_date_str, FechaFinal=end_date_str,
+                    Nombre=bccr_username, SubNiveles='N', CorreoElectronico=bccr_email, Token=bccr_token)
+                xml_response_venta = xml.etree.ElementTree.fromstring(response_venta)
+                selling_rate_nodes = xml_response_venta.findall("./INGC011_CAT_INDICADORECONOMIC")
+                
+                # Obtener la tasa de compra (317)
+                response_compra = client.service.ObtenerIndicadoresEconomicosXML(
+                    Indicador='317', FechaInicio=initial_date_str, FechaFinal=end_date_str,
+                    Nombre=bccr_username, SubNiveles='N', CorreoElectronico=bccr_email, Token=bccr_token)
+                xml_response_compra = xml.etree.ElementTree.fromstring(response_compra)
+                buying_rate_nodes = xml_response_compra.findall("./INGC011_CAT_INDICADORECONOMIC")
 
-            response = client.service.ObtenerIndicadoresEconomicosXML(
-                Indicador='318', FechaInicio=initial_date, FechaFinal=end_date,
-                Nombre=bccr_username, SubNiveles='N', CorreoElectronico=bccr_email, Token=bccr_token)
+            except Exception as e:
+                _logger.error("Error connecting to BCCR API: %s", e)
+                return False
 
-            xml_response = xml.etree.ElementTree.fromstring(response)
-            selling_rate_nodes = xml_response.findall("./INGC011_CAT_INDICADORECONOMIC")
-
-            # Get Buying exchange Rate from BCCR
-            response = client.service.ObtenerIndicadoresEconomicosXML(
-                Indicador='317', FechaInicio=initial_date, FechaFinal=end_date,
-                Nombre=bccr_username, SubNiveles='N', CorreoElectronico=bccr_email, Token=bccr_token)
-
-            xml_response = xml.etree.ElementTree.fromstring(response)
-            buying_rate_nodes = xml_response.findall("./INGC011_CAT_INDICADORECONOMIC")
-
-            selling_rate = 0
-            buying_rate = 0
-            node_index = 0
             if len(selling_rate_nodes) > 0 and len(selling_rate_nodes) == len(buying_rate_nodes):
-                while node_index < len(selling_rate_nodes):
-                    if selling_rate_nodes[node_index].find("DES_FECHA").text == \
-                       buying_rate_nodes[node_index].find("DES_FECHA").text:
-                        current_date_str = datetime.strptime(selling_rate_nodes[node_index].find("DES_FECHA").text,
+                for node_venta, node_compra in zip(selling_rate_nodes, buying_rate_nodes):
+                    if node_venta.find("DES_FECHA").text == node_compra.find("DES_FECHA").text:
+                        current_date_str = datetime.strptime(node_venta.find("DES_FECHA").text,
                                                              "%Y-%m-%dT%H:%M:%S-06:00").strftime('%Y-%m-%d')
+                        
+                        selling_original_rate = float(node_venta.find("NUM_VALOR").text)
+                        buying_original_rate = float(node_compra.find("NUM_VALOR").text)
 
-                        selling_original_rate = float(selling_rate_nodes[node_index].find("NUM_VALOR").text)
-                        buying_original_rate = float(buying_rate_nodes[node_index].find("NUM_VALOR").text)
-
-                        # Odoo uses the value of 1 unit of the base currency divided between the exchage rate
+                        # Odoo usa el valor inverso
                         selling_rate = 1 / selling_original_rate
                         buying_rate = 1 / buying_original_rate
 
-                        # GET THE CURRENCY ID
-                        currency_id = self.env['res.currency'].search([('name', '=', 'USD')], limit=1)
+                        # Buscar la tasa de cambio con el contexto de la compañía principal
+                        rates_ids = currency_rate_obj.search([
+                            ('name', '=', current_date_str),
+                            ('currency_id', '=', usd_currency.id),
+                        ], limit=1)
 
-                        # Get the rate for this date to know it is already registered
-                        companies = self.env['res.company'].search([])
-                        for company in companies:
-                            _logger.error(company.id)
-                            rates_ids = self.env['res.currency.rate'].search([('name', '=', current_date_str),
-                                                                              ('company_id', '=', company.id)],
-                                                                             limit=1)
+                        vals = {
+                            'rate': selling_rate,
+                            'inverse_company_rate': selling_original_rate,
+                            'original_rate': selling_original_rate,
+                            'rate_2': buying_rate,
+                            'original_rate_2': buying_original_rate,
+                            'currency_id': usd_currency.id,
+                            'company_id': main_company.id, 
+                        }
 
-                            if len(rates_ids) > 0:
-                                rates_ids.sudo().write({
-                                    'rate': selling_rate,
-                                    'inverse_company_rate': selling_original_rate,
-                                    'original_rate': selling_original_rate,
-                                    'rate_2': buying_rate,
-                                    'original_rate_2': buying_original_rate,
-                                    'currency_id': currency_id.id,
-                                    'company_id': company.id
-                                    })
-                            else:
-                                self.sudo().create(
-                                    {'name': current_date_str,
-                                    'rate': selling_rate,
-                                    'inverse_company_rate': selling_original_rate,
-                                    'original_rate': selling_original_rate,
-                                    'rate_2': buying_rate,
-                                    'original_rate_2': buying_original_rate,
-                                    'currency_id': currency_id.id,
-                                    'company_id': company.id})
+                        if rates_ids:
+                            # Actualizar el registro existente
+                            rates_ids.write(vals)
+                        else:
+                            # Crear el nuevo registro usando el objeto con el contexto correcto
+                            vals['name'] = current_date_str
+                            currency_rate_obj.create(vals)
 
-                        _logger.info({'name': current_date_str,
-                                      'rate': selling_rate,
-                                      'inverse_company_rate': selling_original_rate,
-                                      'original_rate': selling_original_rate,
-                                      'rate_2': buying_rate,
-                                      'original_rate_2': buying_original_rate,
-                                      # 'inverse_company_rate_2': buying_original_rate,
-                                      'currency_id': currency_id.id})
                     else:
-                        buy_des_fecha = buying_rate_nodes[node_index].find("DES_FECHA").text
-                        sell_des_fecha = selling_rate_nodes[node_index].find("DES_FECHA").text
-                        _logger.error("Error loading currency rates, dates for a buying (%s) ", buy_des_fecha)
-                        _logger.error("and selling (%s) rates don't match", sell_des_fecha)
-
-                    node_index += 1
+                        _logger.error("Error loading currency rates, dates for a buying and selling rates don't match")
             else:
-                _logger.error("Error loading currency rates,dates range data for buying and selling rates don't match")
+                _logger.error("Error loading currency rates, data for buying and selling rates don't match")
 
-        if exchange_source == 'hacienda':
+        elif exchange_source == 'hacienda':
             _logger.info("Getting exchange rates from HACIENDA")
+            
+            initial_date = first_date if first_date else datetime.now().date()
+            end_date = last_date if last_date else initial_date
 
-            # Get current date to get exchange rate for today
-            if first_date:
-                initial_date = first_date.strftime('%Y-%m-%d')
-                end_date = last_date.strftime('%Y-%m-%d')
+            try:
+                url = 'https://api.hacienda.go.cr/indicadores/tc/dolar/historico/?d='+initial_date.strftime('%Y-%m-%d')+'&h='+end_date.strftime('%Y-%m-%d')
+                response = requests.get(url, timeout=5, verify=False)
+                response.raise_for_status()
+                data = response.json()
+            except requests.exceptions.RequestException as e:
+                _logger.error('RequestException %s', e)
+                return False
 
-                try:
-                    url = 'https://api.hacienda.go.cr/indicadores/tc/dolar/historico/?d='+initial_date+'&h='+end_date
-                    response = requests.get(url, timeout=5, verify=False)
-
-                except requests.exceptions.RequestException as e:
-                    _logger.error('RequestException %s', e)
-                    return False
-                if response.status_code in (200,):
-                    data = response.json()
-
+            if response.status_code in (200,):
+                if isinstance(data, list):
                     for rate_line in data:
                         today = datetime.strptime(rate_line['fecha'], '%Y-%m-%d %H:%M:%S')
-                        vals = {}
-                        vals['original_rate'] = rate_line['venta']
-                        vals['inverse_company_rate'] = rate_line['venta']
-                        # Odoo utiliza un valor inverso,
-                        # a cuantos dólares equivale 1 colón, por eso se divide 1 / tipo de cambio.
-                        vals['rate'] = 1 / rate_line['original_rate']
-                        vals['original_rate_2'] = rate_line['compra']
-                        # vals['inverse_company_rate_2'] = rate_line['compra']
-                        vals['rate_2'] = 1 / rate_line['original_rate_2']
-                        vals['currency_id'] = self.env.ref('base.USD').id
-
-                        companies = self.env['res.company'].search([])
-                        for company in companies:
-                            _logger.error(company.id)
-                            rate_id = self.env['res.currency.rate'].search([('name', '=', today.date()),
-                                                                            ('company_id', '=', company.id)], limit=1)
-                            vals['company_id'] = company.id
-                            if rate_id:
-                                rate_id.sudo().write(vals)
-                            else:
-                                vals['name'] = today.date()
-                                self.sudo().create(vals)
-            else:
-                try:
-                    url = 'https://api.hacienda.go.cr/indicadores/tc'
-                    response = requests.get(url, timeout=5, verify=False)
-
-                except requests.exceptions.RequestException as e:
-                    _logger.error('RequestException %s', e)
-                    return False
-
-                if response.status_code in (200,):
-                    # Save the exchange rate in database
-                    today = datetime.now().strftime('%Y-%m-%d')
-                    data = response.json()
-                    vals = {}
-                    vals['original_rate'] = data['dolar']['venta']['valor']
-                    vals['inverse_company_rate'] = data['dolar']['venta']['valor']
-
-                    # Odoo utiliza un valor inverso,
-                    # a cuantos dólares equivale 1 colón, por eso se divide 1 / tipo de cambio.
-
-                    vals['rate'] = 1 / vals['original_rate']
-                    vals['original_rate_2'] = data['dolar']['compra']['valor']
-                    # vals['inverse_company_rate_2'] = data['dolar']['compra']['valor']
-                    vals['rate_2'] = 1 / vals['original_rate_2']
-                    vals['currency_id'] = self.env.ref('base.USD').id
-
-                    companies = self.env['res.company'].search([])
-                    for company in companies:
-                        _logger.error(company.id)
-                        rate_id = self.env['res.currency.rate'].search([('name', '=', today),
-                                                                        ('company_id', '=', company.id)], limit=1)
-                        vals['company_id'] = company.id
-                        if rate_id:
-                            rate_id.sudo().write(vals)
+                        
+                        rates_ids = currency_rate_obj.search([('name', '=', today.date()),
+                                                            ('currency_id', '=', usd_currency.id),
+                                                            ], limit=1)
+                        
+                        vals = {
+                            'original_rate': rate_line['venta'],
+                            'inverse_company_rate': rate_line['venta'],
+                            'rate': 1 / rate_line['venta'],
+                            'original_rate_2': rate_line['compra'],
+                            'rate_2': 1 / rate_line['compra'],
+                            'currency_id': usd_currency.id,
+                            'company_id': main_company.id,
+                        }
+                        
+                        if rates_ids:
+                            rates_ids.write(vals)
                         else:
-                            vals['name'] = today
-                            self.sudo().create(vals)
-
-                _logger.info(vals)
-
+                            vals['name'] = today.date()
+                            currency_rate_obj.create(vals)
+                else:
+                    _logger.error("Hacienda API returned an unexpected data format.")
+                    
         _logger.info("=========================================================")
 
     def _create_the_latest_exchange_rate_to_date(self, currency, date=None):


### PR DESCRIPTION
1. Request a API de hacienda. Se elimina el uso de `original_rate` y `original_rate2`, los cuales no existen en el json respuesta de hacienda. 
2. Contexto de Compañía Principal: Se eliminó el bucle for company in companies. Ahora se obtienen las tasas de cambio de las APIs, y se crea o actualiza un único registro de tasa de cambio en el contexto de la main_company. La clave company_id se asigna explícitamente al ID de la compañía principal.
3. Llamadas a create(): Se corrigió la llamada a self.sudo().create() por currency_rate_obj.create(), que es la forma correcta de crear un registro en el modelo res.currency.rate usando el objeto de entorno que ya tiene el contexto correcto.
4. Manejo de Errores: Se añadió manejo de excepciones try...except para las llamadas a las APIs externas, lo que hace el código más robusto.
5. Ubicación del Código: Es crucial que este método esté en el modelo res.currency.rate, ya que las llamadas a self.create() o self.write() dentro de él esperan operar sobre ese modelo.